### PR TITLE
Add React-based DevOps Study Dashboard

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,37 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [ dashboard ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v3
+      - name: Copy Dashboard to Root
+        run: |
+          cp -r dashboard/* .
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: '.'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -1,0 +1,45 @@
+# DevOps Study Dashboard
+
+A simple React-based dashboard for browsing DevOps study materials related to AWS and GCP.
+
+## Features
+
+- Browse AWS and GCP documentation in Markdown format
+- View PDF resources
+- Search functionality
+- Responsive design
+- Dark mode toggle
+- Collapsible sidebar
+
+## Project Structure
+
+```
+dashboard/
+├── index.html         # Main HTML file
+├── styles.css         # CSS styles
+├── app.js             # React application code
+└── README.md          # Project documentation
+```
+
+## How to Use
+
+1. Open the `index.html` file in a web browser
+2. Use the sidebar to navigate between different documentation files
+3. Use the search bar to filter documents
+4. Toggle dark mode using the moon/sun icon
+5. Collapse the sidebar for more reading space
+
+## Implementation Notes
+
+- This dashboard is a client-side only application using React
+- Content is loaded from the GitHub repository
+- PDF files are displayed using an embedded Google Docs viewer
+- Markdown files are rendered using the markdown-it library
+
+## Future Improvements
+
+- Add a table of contents for each document
+- Implement full-text search across all documents
+- Add bookmarking functionality
+- Implement a history feature
+- Add syntax highlighting for code blocks

--- a/dashboard/app.js
+++ b/dashboard/app.js
@@ -1,0 +1,349 @@
+// Data structure for AWS and GCP documentation
+const AWS_DOCS = [
+  { title: 'API Gateway', path: 'AWS/API_Gateway.md', icon: 'fa-solid fa-network-wired' },
+  { title: 'AWS CLI Commands', path: 'AWS/aws-cli-commands-reference.md', icon: 'fa-solid fa-terminal' },
+  { title: 'CloudFormation', path: 'AWS/CloudFormation.md', icon: 'fa-solid fa-layer-group' },
+  { title: 'CloudFront', path: 'AWS/CloudFront.md', icon: 'fa-solid fa-globe' },
+  { title: 'CloudWatch', path: 'AWS/CloudWatch.md', icon: 'fa-solid fa-chart-line' },
+  { title: 'DynamoDB', path: 'AWS/DynamoDB.md', icon: 'fa-solid fa-database' },
+  { title: 'EBS', path: 'AWS/EBS.md', icon: 'fa-solid fa-hard-drive' },
+  { title: 'EC2', path: 'AWS/EC2.md', icon: 'fa-solid fa-server' },
+  { title: 'ECS', path: 'AWS/ECS.md', icon: 'fa-solid fa-ship' },
+  { title: 'IAM', path: 'AWS/IAM.md', icon: 'fa-solid fa-user-shield' },
+  { title: 'Lambda', path: 'AWS/Lambda.md', icon: 'fa-solid fa-code' },
+  { title: 'Networking', path: 'AWS/Networking.md', icon: 'fa-solid fa-network-wired' },
+  { title: 'RDS', path: 'AWS/RDS.md', icon: 'fa-solid fa-database' },
+  { title: 'Route53', path: 'AWS/Route53.md', icon: 'fa-solid fa-route' },
+  { title: 'S3', path: 'AWS/S3.md', icon: 'fa-solid fa-cube' },
+  { title: 'SNS & SQS', path: 'AWS/SNS_SQS.md', icon: 'fa-solid fa-bell' },
+  { title: 'Storage', path: 'AWS/storage.md', icon: 'fa-solid fa-hdd' },
+  { title: 'VPC', path: 'AWS/VPC.md', icon: 'fa-solid fa-network-wired' },
+  { title: 'GCloud Commands', path: 'AWS/gcloud-commands-reference.md', icon: 'fa-solid fa-terminal' },
+  { title: 'GCP-AWS Migration', path: 'AWS/gcp-aws-migration.md', icon: 'fa-solid fa-exchange-alt' },
+];
+
+const GCP_DOCS = [
+  { title: 'Cloud Functions', path: 'GCP/CloudFunctions.md', icon: 'fa-solid fa-bolt' },
+  { title: 'Cloud Storage', path: 'GCP/CloudStorage.md', icon: 'fa-solid fa-database' },
+  { title: 'Compute Engine', path: 'GCP/ComputeEngine.md', icon: 'fa-solid fa-server' },
+  { title: 'GKE', path: 'GCP/GKE.md', icon: 'fa-solid fa-dharmachakra' },
+  { title: 'IAM', path: 'GCP/IAM.md', icon: 'fa-solid fa-user-shield' },
+  { title: 'VPC', path: 'GCP/VPC.md', icon: 'fa-solid fa-network-wired' },
+];
+
+const AWS_PDF_DOCS = [
+  { title: 'AMI Restoration Troubleshooting Guide', path: 'AWS/123/AMI_Restoration_Troubleshooting_Guide.pdf', icon: 'fa-solid fa-file-pdf' },
+  { title: 'AWS Implementation Q&A', path: 'AWS/123/AWS_Implementation_QA.pdf', icon: 'fa-solid fa-file-pdf' },
+  { title: 'AWS Implementation Q&A with Diagrams', path: 'AWS/123/AWS_Implementation_QA_with_Diagrams.pdf', icon: 'fa-solid fa-file-pdf' },
+  { title: 'Cloud DevOps Networking Q&A', path: 'AWS/123/Cloud_DevOps_Networking_QA.pdf', icon: 'fa-solid fa-file-pdf' },
+  { title: 'Cloud Q&A with All Diagrams', path: 'AWS/123/Cloud_QA_with_All_Diagrams.pdf', icon: 'fa-solid fa-file-pdf' },
+  { title: 'Cloud Q&A with Diagrams', path: 'AWS/123/Cloud_QA_with_Diagrams.pdf', icon: 'fa-solid fa-file-pdf' },
+  { title: 'Cloud Q&A with Visual Diagram', path: 'AWS/123/Cloud_QA_with_Visual_Diagram.pdf', icon: 'fa-solid fa-file-pdf' },
+  { title: 'Detailed Cloud DevOps Networking Q&A', path: 'AWS/123/Detailed_Cloud_DevOps_Networking_QA.pdf', icon: 'fa-solid fa-file-pdf' },
+];
+
+// Create a markdown renderer
+const md = window.markdownit();
+
+// Main App Component
+const App = () => {
+  const [sidebarCollapsed, setSidebarCollapsed] = React.useState(false);
+  const [activeDocument, setActiveDocument] = React.useState(null);
+  const [documentContent, setDocumentContent] = React.useState('');
+  const [searchQuery, setSearchQuery] = React.useState('');
+  const [isDarkMode, setIsDarkMode] = React.useState(false);
+  const [showBackToTop, setShowBackToTop] = React.useState(false);
+  const [isPdf, setIsPdf] = React.useState(false);
+  const [isLoading, setIsLoading] = React.useState(false);
+
+  // Toggle sidebar collapse
+  const toggleSidebar = () => {
+    setSidebarCollapsed(!sidebarCollapsed);
+  };
+
+  // Toggle dark mode
+  const toggleDarkMode = () => {
+    setIsDarkMode(!isDarkMode);
+    document.body.classList.toggle('dark-mode');
+  };
+
+  // Fetch document content
+  const fetchDocument = async (docPath) => {
+    setIsLoading(true);
+    try {
+      // In a real app, we would fetch the content from the server
+      // Since this is a local demo, we'll use placeholder content
+      if (docPath.endsWith('.pdf')) {
+        setIsPdf(true);
+        // PDF file - we don't need to fetch text content
+        setDocumentContent(``);
+      } else {
+        setIsPdf(false);
+        // For markdown files, we would fetch the actual content
+        // For demo purposes, we'll use EC2.md content as a placeholder
+        setDocumentContent(`# ${docPath.split('/').pop().replace('.md', '')}\n\nThis is a placeholder for the content of ${docPath}. In a real implementation, we would fetch the actual content from the server.`);
+      }
+      
+      setActiveDocument(docPath);
+    } catch (error) {
+      console.error('Error fetching document:', error);
+      setDocumentContent('Error loading document');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // Handle document selection
+  const handleDocumentClick = (docPath) => {
+    fetchDocument(docPath);
+  };
+
+  // Filter documents based on search query
+  const filterDocuments = (docs) => {
+    if (!searchQuery) return docs;
+    return docs.filter(doc =>
+      doc.title.toLowerCase().includes(searchQuery.toLowerCase())
+    );
+  };
+
+  // Scroll event handler for back-to-top button
+  React.useEffect(() => {
+    const handleScroll = () => {
+      setShowBackToTop(window.scrollY > 300);
+    };
+
+    window.addEventListener('scroll', handleScroll);
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, []);
+
+  // Scroll to top function
+  const scrollToTop = () => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  };
+
+  // Render document content
+  const renderDocumentContent = () => {
+    if (isLoading) {
+      return <div className="loading">Loading...</div>;
+    }
+
+    if (!activeDocument) {
+      return (
+        <div className="welcome-content">
+          <h1>Welcome to DevOps Study Dashboard</h1>
+          <p>Select a document from the sidebar to get started.</p>
+          
+          <div className="content-section">
+            <div className="content-section-header">
+              <h2 className="content-section-title">AWS Documentation</h2>
+            </div>
+            <div className="card-grid">
+              {AWS_DOCS.slice(0, 6).map((doc, index) => (
+                <div key={index} className="card" onClick={() => handleDocumentClick(doc.path)}>
+                  <div className="card-header">
+                    <div className="card-icon">
+                      <i className={doc.icon}></i>
+                    </div>
+                    <h3 className="card-title">{doc.title}</h3>
+                  </div>
+                  <div className="card-content">
+                    Click to view documentation about {doc.title}.
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+          
+          <div className="content-section">
+            <div className="content-section-header">
+              <h2 className="content-section-title">GCP Documentation</h2>
+            </div>
+            <div className="card-grid">
+              {GCP_DOCS.slice(0, 6).map((doc, index) => (
+                <div key={index} className="card" onClick={() => handleDocumentClick(doc.path)}>
+                  <div className="card-header">
+                    <div className="card-icon">
+                      <i className={doc.icon}></i>
+                    </div>
+                    <h3 className="card-title">{doc.title}</h3>
+                  </div>
+                  <div className="card-content">
+                    Click to view documentation about {doc.title}.
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      );
+    }
+
+    if (isPdf) {
+      return (
+        <div>
+          <div className="breadcrumb">
+            <div className="breadcrumb-item">
+              <a href="#" className="breadcrumb-link" onClick={() => setActiveDocument(null)}>Home</a>
+            </div>
+            <div className="breadcrumb-item">
+              <a href="#" className="breadcrumb-link">{activeDocument.split('/')[0]}</a>
+            </div>
+            <div className="breadcrumb-item">
+              <span className="breadcrumb-link">{activeDocument.split('/').pop()}</span>
+            </div>
+          </div>
+          <h1>{activeDocument.split('/').pop()}</h1>
+          <iframe
+            className="pdf-viewer"
+            src={`https://docs.google.com/viewer?url=https://raw.githubusercontent.com/mushahid25/AWS-GCP/dashboard/${activeDocument}&embedded=true`}
+            frameBorder="0"
+          ></iframe>
+          <p><em>Note: If the PDF doesn't load, please <a href={`https://raw.githubusercontent.com/mushahid25/AWS-GCP/dashboard/${activeDocument}`} target="_blank" rel="noopener noreferrer">click here</a> to view it directly.</em></p>
+        </div>
+      );
+    }
+
+    return (
+      <div>
+        <div className="breadcrumb">
+          <div className="breadcrumb-item">
+            <a href="#" className="breadcrumb-link" onClick={() => setActiveDocument(null)}>Home</a>
+          </div>
+          <div className="breadcrumb-item">
+            <a href="#" className="breadcrumb-link">{activeDocument.split('/')[0]}</a>
+          </div>
+          <div className="breadcrumb-item">
+            <span className="breadcrumb-link">{activeDocument.split('/').pop()}</span>
+          </div>
+        </div>
+        <div 
+          className="markdown-content"
+          dangerouslySetInnerHTML={{ __html: md.render(documentContent) }}
+        />
+      </div>
+    );
+  };
+
+  return (
+    <div className="container">
+      {/* Sidebar */}
+      <div className={`sidebar ${sidebarCollapsed ? 'sidebar-collapsed' : ''}`}>
+        <div className="sidebar-header">
+          <div className="logo">
+            <i className="fa-solid fa-cloud"></i>
+            {!sidebarCollapsed && <span>DevOps Study</span>}
+          </div>
+          <button className="toggle-btn" onClick={toggleSidebar}>
+            <i className={`fa-solid ${sidebarCollapsed ? 'fa-chevron-right' : 'fa-chevron-left'}`}></i>
+          </button>
+        </div>
+        
+        {!sidebarCollapsed && (
+          <>
+            <div className="search-bar">
+              <i className="fa-solid fa-search"></i>
+              <input 
+                type="text" 
+                placeholder="Search documentation..."
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+              />
+            </div>
+            
+            <div className="nav-section">
+              <h3>AWS Documentation</h3>
+              <ul className="nav-items">
+                {filterDocuments(AWS_DOCS).map((doc, index) => (
+                  <li 
+                    key={index} 
+                    className={`nav-item ${activeDocument === doc.path ? 'active' : ''}`}
+                    onClick={() => handleDocumentClick(doc.path)}
+                  >
+                    <a href="#" className="nav-link">
+                      <i className={doc.icon}></i>
+                      <span>{doc.title}</span>
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+            
+            <div className="nav-section">
+              <h3>GCP Documentation</h3>
+              <ul className="nav-items">
+                {filterDocuments(GCP_DOCS).map((doc, index) => (
+                  <li 
+                    key={index} 
+                    className={`nav-item ${activeDocument === doc.path ? 'active' : ''}`}
+                    onClick={() => handleDocumentClick(doc.path)}
+                  >
+                    <a href="#" className="nav-link">
+                      <i className={doc.icon}></i>
+                      <span>{doc.title}</span>
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+            
+            <div className="nav-section">
+              <h3>PDF Resources</h3>
+              <ul className="nav-items">
+                {filterDocuments(AWS_PDF_DOCS).map((doc, index) => (
+                  <li 
+                    key={index} 
+                    className={`nav-item ${activeDocument === doc.path ? 'active' : ''}`}
+                    onClick={() => handleDocumentClick(doc.path)}
+                  >
+                    <a href="#" className="nav-link">
+                      <i className={doc.icon}></i>
+                      <span>{doc.title}</span>
+                    </a>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </>
+        )}
+      </div>
+      
+      {/* Main Content */}
+      <div className="content">
+        <div className="content-header">
+          <h1 className="content-title">
+            {activeDocument ? activeDocument.split('/').pop().replace('.md', '') : 'DevOps Study Dashboard'}
+          </h1>
+          <div style={{ display: 'flex', alignItems: 'center' }}>
+            {!sidebarCollapsed && (
+              <div className="search-bar">
+                <i className="fa-solid fa-search"></i>
+                <input 
+                  type="text" 
+                  placeholder="Search documentation..."
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                />
+              </div>
+            )}
+            <button className="dark-mode-toggle" onClick={toggleDarkMode}>
+              <i className={`fa-solid ${isDarkMode ? 'fa-sun' : 'fa-moon'}`}></i>
+            </button>
+          </div>
+        </div>
+        
+        {renderDocumentContent()}
+      </div>
+      
+      {/* Back to Top Button */}
+      <div 
+        className={`back-to-top ${showBackToTop ? 'visible' : ''}`}
+        onClick={scrollToTop}
+      >
+        <i className="fa-solid fa-chevron-up"></i>
+      </div>
+    </div>
+  );
+};
+
+// Render the App
+ReactDOM.render(<App />, document.getElementById('app'));

--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>DevOps Study Dashboard</title>
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css" rel="stylesheet">
+  <link href="styles.css" rel="stylesheet">
+</head>
+<body>
+  <div id="app"></div>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/react/18.2.0/umd/react.production.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/18.2.0/umd/react-dom.production.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-standalone/7.18.13/babel.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/markdown-it/12.3.2/markdown-it.min.js"></script>
+  <script type="text/babel" src="app.js"></script>
+</body>
+</html>

--- a/dashboard/styles.css
+++ b/dashboard/styles.css
@@ -1,0 +1,409 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  line-height: 1.6;
+  color: #333;
+  background-color: #f5f7fa;
+}
+
+.container {
+  display: flex;
+  min-height: 100vh;
+}
+
+.sidebar {
+  width: 280px;
+  background-color: #1e293b;
+  color: #e2e8f0;
+  padding: 1.5rem;
+  overflow-y: auto;
+  transition: all 0.3s ease;
+}
+
+.sidebar-collapsed {
+  width: 80px;
+}
+
+.logo {
+  display: flex;
+  align-items: center;
+  margin-bottom: 2rem;
+  font-size: 1.5rem;
+  font-weight: bold;
+}
+
+.logo i {
+  margin-right: 0.75rem;
+  font-size: 1.75rem;
+  color: #38bdf8;
+}
+
+.sidebar-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1.5rem;
+}
+
+.toggle-btn {
+  background: none;
+  border: none;
+  color: #e2e8f0;
+  cursor: pointer;
+  font-size: 1.25rem;
+}
+
+.nav-section {
+  margin-bottom: 1.5rem;
+}
+
+.nav-section h3 {
+  color: #94a3b8;
+  font-size: 0.875rem;
+  margin-bottom: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.nav-items {
+  list-style: none;
+}
+
+.nav-item {
+  margin-bottom: 0.25rem;
+  border-radius: 0.375rem;
+  transition: all 0.2s;
+}
+
+.nav-item:hover {
+  background-color: #2c3e50;
+}
+
+.nav-item.active {
+  background-color: #3b82f6;
+}
+
+.nav-item.active a {
+  color: white;
+}
+
+.nav-link {
+  display: flex;
+  align-items: center;
+  padding: 0.75rem;
+  color: #e2e8f0;
+  text-decoration: none;
+  border-radius: 0.375rem;
+  transition: all 0.2s;
+}
+
+.nav-link i {
+  margin-right: 0.75rem;
+  font-size: 1.25rem;
+  width: 20px;
+  text-align: center;
+}
+
+.content {
+  flex-grow: 1;
+  padding: 2rem;
+  overflow-y: auto;
+}
+
+.content-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 2rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+.content-title {
+  font-size: 1.875rem;
+  font-weight: bold;
+  color: #1e293b;
+}
+
+.search-bar {
+  position: relative;
+  width: 100%;
+  max-width: 400px;
+}
+
+.search-bar input {
+  width: 100%;
+  padding: 0.75rem 1rem 0.75rem 2.5rem;
+  border-radius: 0.5rem;
+  border: 1px solid #e2e8f0;
+  font-size: 0.875rem;
+  background-color: white;
+  transition: all 0.2s;
+}
+
+.search-bar input:focus {
+  outline: none;
+  border-color: #3b82f6;
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.3);
+}
+
+.search-bar i {
+  position: absolute;
+  left: 1rem;
+  top: 50%;
+  transform: translateY(-50%);
+  color: #94a3b8;
+}
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.card {
+  background-color: white;
+  border-radius: 0.5rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  padding: 1.5rem;
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.card:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+}
+
+.card-header {
+  display: flex;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.card-icon {
+  width: 40px;
+  height: 40px;
+  background-color: #ebf5ff;
+  color: #3b82f6;
+  border-radius: 0.375rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-right: 1rem;
+  font-size: 1.25rem;
+}
+
+.card-title {
+  font-size: 1.25rem;
+  font-weight: bold;
+  color: #1e293b;
+}
+
+.card-content {
+  color: #64748b;
+  font-size: 0.875rem;
+  line-height: 1.5;
+}
+
+.content-section {
+  margin-bottom: 2rem;
+}
+
+.content-section-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.content-section-title {
+  font-size: 1.25rem;
+  font-weight: bold;
+  color: #1e293b;
+}
+
+.view-all {
+  color: #3b82f6;
+  text-decoration: none;
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+
+.markdown-content {
+  background-color: white;
+  border-radius: 0.5rem;
+  padding: 2rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.05);
+  line-height: 1.8;
+}
+
+.markdown-content h1 {
+  font-size: 2rem;
+  margin-bottom: 1.5rem;
+  color: #1e293b;
+}
+
+.markdown-content h2 {
+  font-size: 1.5rem;
+  margin-top: 2rem;
+  margin-bottom: 1rem;
+  color: #1e293b;
+}
+
+.markdown-content h3 {
+  font-size: 1.25rem;
+  margin-top: 1.5rem;
+  margin-bottom: 0.75rem;
+  color: #1e293b;
+}
+
+.markdown-content p {
+  margin-bottom: 1rem;
+}
+
+.markdown-content ul, .markdown-content ol {
+  margin-bottom: 1rem;
+  padding-left: 1.5rem;
+}
+
+.markdown-content li {
+  margin-bottom: 0.5rem;
+}
+
+.markdown-content code {
+  background-color: #f1f5f9;
+  padding: 0.25rem 0.5rem;
+  border-radius: 0.25rem;
+  font-family: monospace;
+  font-size: 0.875rem;
+}
+
+.markdown-content pre {
+  background-color: #f8fafc;
+  padding: 1rem;
+  border-radius: 0.5rem;
+  overflow-x: auto;
+  margin-bottom: 1.5rem;
+}
+
+.markdown-content pre code {
+  background-color: transparent;
+  padding: 0;
+  border-radius: 0;
+}
+
+.markdown-content a {
+  color: #3b82f6;
+  text-decoration: none;
+}
+
+.markdown-content a:hover {
+  text-decoration: underline;
+}
+
+.breadcrumb {
+  display: flex;
+  margin-bottom: 1.5rem;
+  font-size: 0.875rem;
+}
+
+.breadcrumb-item {
+  display: flex;
+  align-items: center;
+}
+
+.breadcrumb-item:not(:last-child)::after {
+  content: '/';
+  margin: 0 0.5rem;
+  color: #94a3b8;
+}
+
+.breadcrumb-link {
+  color: #64748b;
+  text-decoration: none;
+}
+
+.breadcrumb-link:hover {
+  color: #3b82f6;
+}
+
+.breadcrumb-item:last-child .breadcrumb-link {
+  color: #1e293b;
+  font-weight: 500;
+}
+
+/* Dark mode toggle button */
+.dark-mode-toggle {
+  background: none;
+  border: none;
+  color: #1e293b;
+  font-size: 1.25rem;
+  cursor: pointer;
+  margin-left: 1rem;
+}
+
+.back-to-top {
+  position: fixed;
+  bottom: 2rem;
+  right: 2rem;
+  background-color: #3b82f6;
+  color: white;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1.25rem;
+  cursor: pointer;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  transition: all 0.2s;
+  opacity: 0;
+  visibility: hidden;
+}
+
+.back-to-top.visible {
+  opacity: 1;
+  visibility: visible;
+}
+
+.back-to-top:hover {
+  background-color: #2563eb;
+  transform: translateY(-5px);
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .container {
+    flex-direction: column;
+  }
+
+  .sidebar {
+    width: 100%;
+    max-height: 300px;
+  }
+
+  .sidebar-collapsed {
+    max-height: 80px;
+    overflow: hidden;
+  }
+  
+  .card-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* PDF Viewer */
+.pdf-viewer {
+  width: 100%;
+  height: 700px;
+  border: 1px solid #e2e8f0;
+  border-radius: 0.5rem;
+  margin-bottom: 1.5rem;
+}


### PR DESCRIPTION
This PR adds a React-based dashboard for browsing the DevOps study materials in the repository. The dashboard allows users to:

- Browse AWS and GCP documentation in Markdown format
- View PDF resources
- Search through documentation
- Toggle between light and dark mode
- Collapse the sidebar for more reading space

The dashboard is deployed via GitHub Pages through a CI/CD workflow.

## Preview
The dashboard provides an intuitive interface to navigate through all the study materials, making it easier to access and read the documentation.

## Implementation
- Built with vanilla React (no build tools required)
- Uses markdown-it for rendering Markdown content
- Uses Google Docs viewer for rendering PDF files
- Fully responsive design

## How to Use
1. Once merged, the dashboard will be available at the GitHub Pages URL
2. Use the sidebar to navigate between different documentation files
3. Use the search bar to filter documents
4. Toggle dark mode using the moon/sun icon
5. Collapse the sidebar for more reading space