### PR TITLE
Fix GitHub Pages 404 error by adding root index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="refresh" content="0;url=dashboard/index.html">
+  <title>DevOps Study Dashboard</title>
+</head>
+<body>
+  <p>Redirecting to the dashboard...</p>
+</body>
+</html>


### PR DESCRIPTION
This PR adds an index.html file to the root directory to fix the GitHub Pages 404 error.

GitHub Pages requires an index.html file in the root directory of the repository or in the configured publishing source. This change adds a simple redirect to the dashboard/index.html file so that the GitHub Pages site works correctly.